### PR TITLE
Fix footer nav causing 404

### DIFF
--- a/bitski_theme/footer.html
+++ b/bitski_theme/footer.html
@@ -4,10 +4,10 @@
   {% if page and page.next_page or page.previous_page %}
     <div class="rst-footer-buttons" role="navigation" aria-label="footer navigation">
       {% if page.next_page %}
-        <a href="{{ page.next_page.url }}" class="btn btn-neutral float-right" title="{{ page.next_page.title }}">Next &rarr;</a>
+        <a href="/{{ page.next_page.url }}" class="btn btn-neutral float-right" title="{{ page.next_page.title }}">Next &rarr;</a>
       {% endif %}
       {% if page.previous_page %}
-        <a href="{{ page.previous_page.url }}" class="btn btn-neutral" title="{{ page.previous_page.title }}">&larr; Previous</a>
+        <a href="/{{ page.previous_page.url }}" class="btn btn-neutral" title="{{ page.previous_page.title }}">&larr; Previous</a>
       {% endif %}
     </div>
   {% endif %}


### PR DESCRIPTION
The current footer nav causes 404s due to relative URLs. This just makes the URLs absolute to fix that.